### PR TITLE
Added more supported versions of py and redis in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         redis-version: [4, 5, 6]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
-        redis-version: [4, 5]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        redis-version: [4, 5, 6]
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
         redis-version: [4, 5, 6]
 
     steps:


### PR DESCRIPTION
I added python 3.9 and redis 6 to the CI
I couldn't manage to add 3.10 it does not seem available !