### PR TITLE
Replaced list comprehension with generators

### DIFF
--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -64,14 +64,15 @@ class RateLimitMiddleware:
                     raise exc
 
                 # Select the first rule that can be matched
-                _rules = [rule for rule in rules if group == rule.group]
-                if _rules:
-                    rule = _rules[0]
+                rule = next((rule for rule in rules if group == rule.group), None)
+                if rule:
                     break
         else:  # If no rule can match, run `self.app` and return
             return await self.app(scope, receive, send)
 
-        if not [name for name in RULENAMES if getattr(rule, name) is not None]:
+        if not next(
+            (name for name in RULENAMES if getattr(rule, name) is not None), None
+        ):
             return await self.app(scope, receive, send)
 
         if rule.zone is None:

--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -64,15 +64,14 @@ class RateLimitMiddleware:
                     raise exc
 
                 # Select the first rule that can be matched
-                rule = next((rule for rule in rules if group == rule.group), None)
+                rule = next(filter(lambda r: r.group == group, rules), None)
                 if rule:
                     break
         else:  # If no rule can match, run `self.app` and return
             return await self.app(scope, receive, send)
 
-        if not next(
-            (name for name in RULENAMES if getattr(rule, name) is not None), None
-        ):
+        # Find if rule have any of required attributes
+        if not any(getattr(rule, name) for name in RULENAMES):
             return await self.app(scope, receive, send)
 
         if rule.zone is None:

--- a/ratelimit/core.py
+++ b/ratelimit/core.py
@@ -59,8 +59,8 @@ class RateLimitMiddleware:
                     user, group = await self.authenticate(scope)
                 except Exception as exc:
                     if self.on_auth_error is not None:
-                        reponse = await self.on_auth_error(exc)
-                        return await reponse(scope, receive, send)
+                        response = await self.on_auth_error(exc)
+                        return await response(scope, receive, send)
                     raise exc
 
                 # Select the first rule that can be matched


### PR DESCRIPTION
Hi! I’ve made some small improvements:
1. Replaced list comprehension with `next(filter(…))`. In this case we won’t iterate over every rule and really return the first rule matched
2. Replaced list comprehension with `any()`. In this case `any()` will return `True` when it founds first required attribute in rule object
3. Fixed small typo in reponse -> response